### PR TITLE
improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ target/
 
 # IntelliJ
 .idea/
+*.iml
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+#macOS
+*.DS_Store

--- a/src/main/java/com/paralyzedfetch/service/ParalyzedFetchWeather.java
+++ b/src/main/java/com/paralyzedfetch/service/ParalyzedFetchWeather.java
@@ -1,16 +1,19 @@
 package com.paralyzedfetch.service;
 
 import com.paralyzedfetch.client.WeatherClient;
+import com.paralyzedfetch.model.WeatherDTO;
 import com.paralyzedfetch.model.WeatherDetailsDTO;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
 
 /**
  * Created by robertoduessmann on 2/5/19
@@ -19,7 +22,8 @@ import java.util.concurrent.TimeUnit;
 @AllArgsConstructor
 public class ParalyzedFetchWeather {
 
-    private static final ForkJoinPool executorService = new ForkJoinPool();
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParalyzedFetchWeather.class);
+    private static final ExecutorService executorService = Executors.newFixedThreadPool(100);
     private static final long TIMEOUT_MINUTES = 60;
 
     private WeatherClient weatherClient;
@@ -30,16 +34,21 @@ public class ParalyzedFetchWeather {
         executorService.awaitTermination(TIMEOUT_MINUTES, TimeUnit.MINUTES);
     }
 
-    public List<WeatherDetailsDTO> fetchWeather(List<String> cities) {
-        List<WeatherDetailsDTO> weathers = Collections.synchronizedList(new ArrayList<>());
-        cities.forEach(city -> executorService.submit(() -> weathers.add(getWeather(city))));
-        executorService.awaitQuiescence(TIMEOUT_MINUTES, TimeUnit.MINUTES);
-        return weathers;
+    public List<WeatherDTO> fetchWeather(List<String> cities) {
+        return cities.stream()
+                .map(c -> executorService.submit(() -> weatherClient.getWeather(c)))
+                .parallel()
+                .map(this::getWeather)
+                .collect(Collectors.toList());
     }
 
-    private WeatherDetailsDTO getWeather(String city) {
-        WeatherDetailsDTO weather = weatherClient.getWeather(city);
-        weather.setCity(city);
-        return weather;
+    private WeatherDTO getWeather(Future<WeatherDetailsDTO> weatherDetailsDTOFuture){
+        try {
+            WeatherDetailsDTO weatherDetailsDTO = weatherDetailsDTOFuture.get();
+            return new WeatherDTO(weatherDetailsDTO.getCity(), weatherDetailsDTO.getTemperature());
+        } catch (Exception e) {
+            LOGGER.error("Error occurred", e);
+            return new WeatherDTO();
+        }
     }
 }

--- a/src/main/java/com/paralyzedfetch/service/WeatherService.java
+++ b/src/main/java/com/paralyzedfetch/service/WeatherService.java
@@ -18,10 +18,7 @@ public class WeatherService {
     private ParalyzedFetchWeather paralyzedFetchWeather;
 
     public List<WeatherDTO> getWeather() {
-        return paralyzedFetchWeather.fetchWeather(cityReader.read())
-                .stream()
-                .map(weather -> new WeatherDTO(weather.getCity(), weather.getTemperature()))
-                .collect(Collectors.toList());
+        return paralyzedFetchWeather.fetchWeather(cityReader.read());
     }
 
 }


### PR DESCRIPTION
This should improve performance. As the weather API responds very fast for a single city, we can call it with more threads. I set a 100 fixed thread pool but we can even increase this if the API can handle.
Also using `Future` is cleaner and easy to read and manage threads than waiting for all threads to finish their tasks (`executorService.awaitQuiescence(TIMEOUT_MINUTES, TimeUnit.MINUTES);`)